### PR TITLE
Add combo growth and keyboard control

### DIFF
--- a/src/components/ThreeContainer.js
+++ b/src/components/ThreeContainer.js
@@ -9,6 +9,7 @@ class ThreeContainer extends Component {
     this.isSceneEndHandled = false;
     this.animate = this.animate.bind(this);
     this.handleMouseClick = this.handleMouseClick.bind(this);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
   }
 
   componentDidMount() {
@@ -16,6 +17,7 @@ class ThreeContainer extends Component {
       const mountPoint = this.mountPoint;
       mountPoint.appendChild(this.manager.renderer.domElement);
       window.addEventListener('resize', this.manager.handleWindowResize, false);
+      window.addEventListener('keydown', this.handleKeyPress, false);
       this.animate();
     }
   }
@@ -36,6 +38,7 @@ class ThreeContainer extends Component {
       cancelAnimationFrame(this.frameId);
       mountPoint.removeChild(currRenderer.domElement);
       window.removeEventListener('resize', currManager.handleWindowResize);
+      window.removeEventListener('keydown', this.handleKeyPress);
       return true;
     }
 
@@ -51,6 +54,7 @@ class ThreeContainer extends Component {
       this.manager = manager;
       mountPoint.appendChild(renderer.domElement);
       window.addEventListener('resize', this.manager.handleWindowResize, false);
+      window.addEventListener('keydown', this.handleKeyPress, false);
       this.animate();
     }
   }
@@ -62,6 +66,7 @@ class ThreeContainer extends Component {
     if (this.manager !== null) {
       this.mountPoint.removeChild(this.manager.renderer.domElement);
     }
+    window.removeEventListener('keydown', this.handleKeyPress);
   }
 
   animate() {
@@ -81,6 +86,13 @@ class ThreeContainer extends Component {
 
   handleMouseClick() {
     this.manager.handleMouseClick();
+  }
+
+  handleKeyPress(event) {
+    if (event.code === 'Space' || event.key === ' ') {
+      event.preventDefault();
+      this.manager.handleMouseClick();
+    }
   }
 
   render() {

--- a/src/components/three/GameScene.js
+++ b/src/components/three/GameScene.js
@@ -100,6 +100,13 @@ class GameScene {
           }
           if (res.case === 'overlap') {
             this.state.combo += 1;
+            // if player made three or more perfect stacks in a row, enlarge the
+            // current brick up to its original size
+            if (this.state.combo >= 3) {
+              const mesh = this.bricks[height - 1].mesh;
+              mesh.scale.x = Math.min(1, mesh.scale.x + 0.1);
+              mesh.scale.z = Math.min(1, mesh.scale.z + 0.1);
+            }
           }
           this.state.score += 1;
           // create new brick
@@ -110,6 +117,7 @@ class GameScene {
               : new THREE.Vector3(-59, currPos.y + 8, currPos.z),
             scale: this.bricks[height - 1].mesh.scale,
             direction: this.bricks[height - 1].params.direction === 'x' ? 'z' : 'x',
+            speed: { h: 50 + height * 2, v: 60 },
           });
           this.bricks.push(newBrick);
           this.scene.add(this.bricks[height].mesh);


### PR DESCRIPTION
## Summary
- treat spacebar keydown the same as mouse click
- bump brick scale when combo reaches 3
- spawn faster bricks over time

## Testing
- `npm test` *(fails: jest not found)*