### PR TITLE
Add pastel color cycle and visual effects

### DIFF
--- a/src/components/three/GameScene.js
+++ b/src/components/three/GameScene.js
@@ -2,8 +2,10 @@ import * as THREE from 'three';
 // import Physijs from 'physijs-webpack/webpack';
 import Brick from './entity/Brick';
 import Cornerstone from './entity/Cornerstone';
+import Ripple from './entity/Ripple';
+import Firework from './entity/Firework';
 import { PhysicSceneModule, RendererModule, CameraModule } from './module/SceneModules';
-import palette from './Palette';
+import palette, { getWheelColor } from './Palette';
 
 class GameScene {
   constructor() {
@@ -17,6 +19,9 @@ class GameScene {
       maxCombo: 0,
       score: 0,
     };
+    this.colorIndex = Math.floor(Math.random() * 8);
+    this.ripples = [];
+    this.fireworks = [];
     this.name = this.scene.uuid;
     // utilities
     this.handleWindowResize = this.handleWindowResize.bind(this);
@@ -53,11 +58,15 @@ class GameScene {
     const baseBrick = new Brick({
       position: new THREE.Vector3(0, -4, 0),
       scale: new THREE.Vector3(1, 1, 1),
+      color: getWheelColor(this.colorIndex),
     });
+    this.colorIndex += 1;
     const currBrick = new Brick({
       position: new THREE.Vector3(0, 4, 0),
       scale: new THREE.Vector3(1, 1, 1),
+      color: getWheelColor(this.colorIndex),
     });
+    this.colorIndex += 1;
     this.bricks.push(baseBrick);
     this.bricks.push(currBrick);
     // scene set up
@@ -100,6 +109,7 @@ class GameScene {
           }
           if (res.case === 'overlap') {
             this.state.combo += 1;
+            this.spawnRipple(this.bricks[height - 1].mesh.position);
           }
           this.state.score += 1;
           // create new brick
@@ -110,7 +120,12 @@ class GameScene {
               : new THREE.Vector3(-59, currPos.y + 8, currPos.z),
             scale: this.bricks[height - 1].mesh.scale,
             direction: this.bricks[height - 1].params.direction === 'x' ? 'z' : 'x',
+            color: getWheelColor(this.colorIndex),
           });
+          if (this.state.combo >= 3) {
+            this.spawnFirework(this.bricks[height - 1].mesh.position);
+          }
+          this.colorIndex += 1;
           this.bricks.push(newBrick);
           this.scene.add(this.bricks[height].mesh);
           this.state.toDrop = false;
@@ -119,7 +134,7 @@ class GameScene {
     }
     // remove some falling bricks to boost performace
     this.fallingBricks.forEach((brick, index) => {
-      if (brick && brick.mesh.position.y < this.camera.position.y - 150) {
+      if (brick && brick.mesh.position.y < this.camera.position.y - 300) {
         this.scene.remove(brick.mesh);
         brick.mesh.geometry.dispose();
         this.fallingBricks.splice(index, 1);
@@ -127,9 +142,39 @@ class GameScene {
         brick.update(deltaTime);
       }
     });
+
+    this.ripples.forEach((ripple, idx) => {
+      ripple.update(deltaTime);
+      if (ripple.isDone()) {
+        this.scene.remove(ripple.mesh);
+        this.ripples.splice(idx, 1);
+      }
+    });
+
+    this.fireworks.forEach((fw, idx) => {
+      fw.update(deltaTime);
+      if (fw.isDone()) {
+        this.scene.remove(fw.points);
+        this.fireworks.splice(idx, 1);
+      }
+    });
     // render scene
     this.scene.simulate();
     this.renderer.render(this.scene, this.camera);
+  }
+
+  spawnRipple(position) {
+    const color = getWheelColor(this.colorIndex);
+    const ripple = new Ripple(position, color);
+    this.ripples.push(ripple);
+    this.scene.add(ripple.mesh);
+  }
+
+  spawnFirework(position) {
+    const color = getWheelColor(this.colorIndex);
+    const fw = new Firework(position, color);
+    this.fireworks.push(fw);
+    this.scene.add(fw.points);
   }
 
   handleWindowResize() {

--- a/src/components/three/Palette.js
+++ b/src/components/three/Palette.js
@@ -10,4 +10,20 @@ const palette = {
   black: 0x000000,
 };
 
+const pastelWheel = [
+  0xffadad,
+  0xffd6a5,
+  0xfdffb6,
+  0xcaffbf,
+  0x9bf6ff,
+  0xa0c4ff,
+  0xbdb2ff,
+  0xffc6ff,
+];
+
+function getWheelColor(index) {
+  return pastelWheel[index % pastelWheel.length];
+}
+
+export { pastelWheel, getWheelColor };
 export default palette;

--- a/src/components/three/entity/FallingBrick.js
+++ b/src/components/three/entity/FallingBrick.js
@@ -28,7 +28,7 @@ class FallingBrick {
   }
 
   update(deltaTime) {
-    Object.getPrototypeOf(this.mesh.material).opacity -= 0.15 * deltaTime;
+    Object.getPrototypeOf(this.mesh.material).opacity -= 0.05 * deltaTime;
   }
 }
 

--- a/src/components/three/entity/Firework.js
+++ b/src/components/three/entity/Firework.js
@@ -1,0 +1,42 @@
+import * as THREE from 'three';
+
+class Firework {
+  constructor(position, color) {
+    const geom = new THREE.BufferGeometry();
+    const positions = [];
+    this.velocities = [];
+    const count = 8;
+    for (let i = 0; i < count; i += 1) {
+      positions.push(0, 0, 0);
+      const v = new THREE.Vector3(
+        (Math.random() * 2 - 1),
+        Math.random() * 2 + 1,
+        (Math.random() * 2 - 1),
+      );
+      this.velocities.push(v);
+    }
+    geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    const mat = new THREE.PointsMaterial({ color, size: 0.5, transparent: true, opacity: 0.8, depthWrite: false });
+    this.points = new THREE.Points(geom, mat);
+    this.points.position.copy(position.clone().add(new THREE.Vector3(0, 0.5, 0)));
+    this.fadeSpeed = 1;
+  }
+
+  update(delta) {
+    const posAttr = this.points.geometry.getAttribute('position');
+    for (let i = 0; i < this.velocities.length; i += 1) {
+      const vx = this.velocities[i];
+      posAttr.array[i * 3] += vx.x * delta * 5;
+      posAttr.array[i * 3 + 1] += vx.y * delta * 5;
+      posAttr.array[i * 3 + 2] += vx.z * delta * 5;
+    }
+    posAttr.needsUpdate = true;
+    this.points.material.opacity -= this.fadeSpeed * delta;
+  }
+
+  isDone() {
+    return this.points.material.opacity <= 0;
+  }
+}
+
+export default Firework;

--- a/src/components/three/entity/Ripple.js
+++ b/src/components/three/entity/Ripple.js
@@ -1,0 +1,25 @@
+import * as THREE from 'three';
+
+class Ripple {
+  constructor(position, color) {
+    const geom = new THREE.PlaneGeometry(2, 2);
+    const mat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.5, depthWrite: false });
+    this.mesh = new THREE.Mesh(geom, mat);
+    this.mesh.rotation.x = -Math.PI / 2;
+    this.mesh.position.copy(position.clone().add(new THREE.Vector3(0, 0.1, 0)));
+    this.scaleSpeed = 4;
+    this.fadeSpeed = 1;
+  }
+
+  update(delta) {
+    this.mesh.scale.x += this.scaleSpeed * delta;
+    this.mesh.scale.y += this.scaleSpeed * delta;
+    this.mesh.material.opacity -= this.fadeSpeed * delta;
+  }
+
+  isDone() {
+    return this.mesh.material.opacity <= 0;
+  }
+}
+
+export default Ripple;

--- a/src/css/threecontainer.css
+++ b/src/css/threecontainer.css
@@ -7,5 +7,10 @@
   height: 100vh;
 	width: 100vw;
 	object-fit: cover;
-	background: linear-gradient(to bottom, #894da5 0%,#41347a 20%,#162d47 43%);
+        background-image:
+          radial-gradient(rgba(255,255,255,0.3) 1px, transparent 1px),
+          radial-gradient(rgba(255,255,255,0.15) 1px, transparent 1px),
+          linear-gradient(to bottom, #a1c6ea 0%, #162d47 80%);
+        background-size: 3px 3px, 2px 2px, 100% 100%;
+        background-position: 0 0, 50px 50px, 0 0;
 }


### PR DESCRIPTION
## Summary
- implement pastel color wheel in Palette
- animate ripples and fireworks on perfect stacks in `GameScene`
- cycle block colors using color wheel
- extend falling brick lifetime
- add starry gradient background

## Testing
- `npm test` *(fails: jest not found)*